### PR TITLE
Refactor menu service for async patterns and domain exceptions

### DIFF
--- a/MenuService/Controllers/MenuController.cs
+++ b/MenuService/Controllers/MenuController.cs
@@ -1,6 +1,7 @@
 
 using AutoMapper;
 using MenuService.Dtos;
+using MenuService.Exceptions;
 using MenuService.Interfaces;
 using MenuService.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -21,48 +22,63 @@ namespace MenuService.Controllers
         }
 
         [HttpPost]
-        public ActionResult<MenuItemReadDto> CreateMenuItem(MenuItemCreateDto menuItemCreateDto)
+        public async Task<ActionResult<MenuItemReadDto>> CreateMenuItem(MenuItemCreateDto menuItemCreateDto)
         {
             var menuItem = _mapper.Map<MenuItem>(menuItemCreateDto);
-            _facade.AddItem(menuItem);
-            
+            await _facade.AddItem(menuItem);
 
             var menuItemReadDto = _mapper.Map<MenuItemReadDto>(menuItem);
             return CreatedAtAction(nameof(GetMenuItemById), new { id = menuItemReadDto.Id }, menuItemReadDto);
         }
 
         [HttpGet]
-        public ActionResult<IEnumerable<MenuItemReadDto>> GetMenuItems()
+        public async Task<ActionResult<IEnumerable<MenuItemReadDto>>> GetMenuItems()
         {
-            var menuItems = _facade.GetAllItems();
+            var menuItems = await _facade.GetAllItems();
             return Ok(_mapper.Map<IEnumerable<MenuItemReadDto>>(menuItems));
         }
 
         [HttpGet("{id}")]
-        public ActionResult<MenuItemReadDto> GetMenuItemById(Guid id)
+        public async Task<ActionResult<MenuItemReadDto>> GetMenuItemById(Guid id)
         {
-            var menuItem = _facade.GetById(id);
-
-            if (menuItem == null)
+            try
+            {
+                var menuItem = await _facade.GetById(id);
+                return Ok(_mapper.Map<MenuItemReadDto>(menuItem));
+            }
+            catch (MenuItemNotFoundException)
             {
                 return NotFound();
             }
-            
-            return Ok(_mapper.Map<MenuItemReadDto>(menuItem));
         }
 
         [HttpPut("{id}")]
-        public IActionResult UpdateMenuItem(MenuItemReadDto menuItemUpdateDto)
+        public async Task<IActionResult> UpdateMenuItem(MenuItemReadDto menuItemUpdateDto)
         {
             var menuItem = _mapper.Map<MenuItem>(menuItemUpdateDto);
-            return Ok(_mapper.Map<MenuItemReadDto>(menuItem));
+            try
+            {
+                await _facade.Update(menuItem);
+                return Ok(_mapper.Map<MenuItemReadDto>(menuItem));
+            }
+            catch (MenuItemNotFoundException)
+            {
+                return NotFound();
+            }
         }
 
         [HttpDelete("{id}")]
-        public IActionResult DeleteMenuItem(Guid id)
+        public async Task<IActionResult> DeleteMenuItem(Guid id)
         {
-            _facade.Delete(id);
-            return Ok();
+            try
+            {
+                await _facade.Delete(id);
+                return Ok();
+            }
+            catch (MenuItemNotFoundException)
+            {
+                return NotFound();
+            }
         }
 
 

--- a/MenuService/Exceptions/MenuItemNotFoundException.cs
+++ b/MenuService/Exceptions/MenuItemNotFoundException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MenuService.Exceptions
+{
+    public class MenuItemNotFoundException : Exception
+    {
+        public MenuItemNotFoundException(Guid id)
+            : base($"Menu item with id '{id}' was not found.")
+        {
+        }
+    }
+}

--- a/MenuService/Facades/MenuServiceFacade.cs
+++ b/MenuService/Facades/MenuServiceFacade.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MenuService.Exceptions;
 using MenuService.Interfaces;
 using MenuService.Models;
 
@@ -12,74 +16,47 @@ namespace MenuService.Facades
             _repo = repo;
         }
 
-        public void AddItem(MenuItem item)
+        public async Task AddItem(MenuItem item)
         {
-            try
-            {
-                _repo.Add(item);
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+            await _repo.AddAsync(item);
         }
 
-        public IEnumerable<MenuItem> GetAllItems()
+        public async Task<IEnumerable<MenuItem>> GetAllItems()
         {
-            try
-            {
-                var allItems = _repo.GetAll();
-                return allItems;
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+            return await _repo.GetAllAsync();
         }
 
-        public MenuItem GetById(Guid id)
+        public async Task<MenuItem> GetById(Guid id)
         {
-            try
+            var item = await _repo.GetByIdAsync(id);
+            if (item == null)
             {
-                var item = _repo.GetById(id);
+                throw new MenuItemNotFoundException(id);
+            }
 
-                if (item == null)
-                {
-                    throw new Exception("Item not found.");
-                }
-                
-                return item;
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+            return item;
         }
 
-        public void Update(MenuItem item)
+        public async Task Update(MenuItem item)
         {
-            try
+            var existing = await _repo.GetByIdAsync(item.Id);
+            if (existing == null)
             {
-                var existing = _repo.GetById(item.Id) ?? throw new Exception("Item not found.");
-                _repo.Update(item);
+                throw new MenuItemNotFoundException(item.Id);
             }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+
+            await _repo.UpdateAsync(item);
         }
 
-        public void Delete(Guid id)
+        public async Task Delete(Guid id)
         {
-            try
+            var existing = await _repo.GetByIdAsync(id);
+            if (existing == null)
             {
-                var existing = _repo.GetById(id) ?? throw new Exception("Item not found.");
-                _repo.Delete(id);
+                throw new MenuItemNotFoundException(id);
             }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+
+            await _repo.DeleteAsync(id);
         }
     }
 }

--- a/MenuService/Interfaces/IMenuRepository.cs
+++ b/MenuService/Interfaces/IMenuRepository.cs
@@ -8,11 +8,11 @@ namespace MenuService.Interfaces
 {
     public interface IMenuRepository
     {
-        void Add(MenuItem item);
-        void Update(MenuItem item);
-        void Delete(Guid id);
-        IEnumerable<MenuItem> GetAll();
-        MenuItem GetById(Guid id);
-        bool SaveChanges();
+        Task AddAsync(MenuItem item);
+        Task UpdateAsync(MenuItem item);
+        Task DeleteAsync(Guid id);
+        Task<IEnumerable<MenuItem>> GetAllAsync();
+        Task<MenuItem?> GetByIdAsync(Guid id);
+        Task<bool> SaveChangesAsync();
     }
 }

--- a/MenuService/Interfaces/IMenuServiceFacade.cs
+++ b/MenuService/Interfaces/IMenuServiceFacade.cs
@@ -1,13 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using MenuService.Models;
 
 namespace MenuService.Interfaces
 {
     public interface IMenuServiceFacade
     {
-        void AddItem(MenuItem item);
-        IEnumerable<MenuItem> GetAllItems();
-        MenuItem GetById(Guid id);
-        void Update(MenuItem item);
-        void Delete(Guid id);
+        Task AddItem(MenuItem item);
+        Task<IEnumerable<MenuItem>> GetAllItems();
+        Task<MenuItem> GetById(Guid id);
+        Task Update(MenuItem item);
+        Task Delete(Guid id);
     }
 }

--- a/MenuService/Repositories/MenuRepository.cs
+++ b/MenuService/Repositories/MenuRepository.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using MenuService.Data;
 using MenuService.Interfaces;
 using MenuService.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace MenuService.Repositories
 {
@@ -13,38 +16,41 @@ namespace MenuService.Repositories
             _context = context;
         }
 
-        public void Add(MenuItem item)
+        public async Task AddAsync(MenuItem item)
         {
-            _context.MenuItems.Add(item);
-            SaveChanges();
+            await _context.MenuItems.AddAsync(item);
+            await SaveChangesAsync();
         }
 
-        public void Update(MenuItem item)
+        public async Task UpdateAsync(MenuItem item)
         {
             _context.MenuItems.Update(item);
-            SaveChanges();
+            await SaveChangesAsync();
         }
 
-        public void Delete(Guid id)
+        public async Task DeleteAsync(Guid id)
         {
-            var item = _context.MenuItems.Find(id);
-            _context.MenuItems.Remove(item);
-            SaveChanges();
+            var item = await _context.MenuItems.FindAsync(id);
+            if (item != null)
+            {
+                _context.MenuItems.Remove(item);
+                await SaveChangesAsync();
+            }
         }
 
-        public IEnumerable<MenuItem> GetAll()
+        public async Task<IEnumerable<MenuItem>> GetAllAsync()
         {
-            return _context.MenuItems.ToList();
+            return await _context.MenuItems.ToListAsync();
         }
 
-        public MenuItem GetById(Guid id)
+        public async Task<MenuItem?> GetByIdAsync(Guid id)
         {
-            return _context.MenuItems.Find(id);
+            return await _context.MenuItems.FindAsync(id);
         }
 
-        public bool SaveChanges()
+        public async Task<bool> SaveChangesAsync()
         {
-            return _context.SaveChanges() > 0;
+            return await _context.SaveChangesAsync() > 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace synchronous menu facade with async `Task`-based methods and propagate calls to repository
- Remove blanket try/catch blocks and throw `MenuItemNotFoundException` when a menu item is missing
- Add async repository methods and update controller actions to await facade and handle domain exceptions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed/403)*


------
https://chatgpt.com/codex/tasks/task_e_68a4770128008325a2106ec8d64f048a